### PR TITLE
[긴급] get_current_user를 utils.auth_dependency에서 가져옴

### DIFF
--- a/app/routers/home_router.py
+++ b/app/routers/home_router.py
@@ -10,7 +10,7 @@ from app.dependencies import (
     get_product_dal,
 )
 
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 
 from app.services.home_service import HomeService
 from app.services.user_daily_score_service import UserDailyScoreService

--- a/app/routers/me_router.py
+++ b/app/routers/me_router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from app.models.user import User 
 
 from app.core.database import get_db
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 from app.schemas.user import (
     MyPageHabitIn,
     MyPageHabitOut,

--- a/app/routers/mypage_router.py
+++ b/app/routers/mypage_router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from app.models.user import User 
 
 from app.core.database import get_db
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 from app.schemas.user import MyPageOut
 from app.services.user_service import UserService
 

--- a/app/routers/scan_flow_router.py
+++ b/app/routers/scan_flow_router.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Form, File, UploadFile, Depends, Body
 from app.schemas.scan_flow import ScanResultOut
 from app.services.scan_flow_service import ScanFlowService
 from app.dependencies import get_scan_flow_service
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 
 router = APIRouter(
     prefix="/v1/scan-history",

--- a/app/routers/scan_history_router.py
+++ b/app/routers/scan_history_router.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.core.database import get_db
 from app.DAL.scan_history_DAL import ScanHistoryDAL
 from app.models.user import User
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 
 from app.services.scan_history_service import ScanHistoryService
 from app.services.scan_get_full_service import ScanGetFullService

--- a/app/routers/user_router.py
+++ b/app/routers/user_router.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 
 from app.models.user import User
 from app.core.database import get_db
-from app.core.auth import get_current_user
+from utils.auth_dependency import get_current_user
 from app.DAL.user_DAL import UserDAL
 from app.schemas.user import (
     UserCreate, UserUpdate, UserOut


### PR DESCRIPTION
라우터 코드들의 get_current_user을 core.auth에서 가져오는 것이 아닌 utils.auth_dependency에서 가져오게 함

연결된 이슈: #9 